### PR TITLE
MacOS>=12 fix

### DIFF
--- a/demo/iokit.c
+++ b/demo/iokit.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 	CFDictionaryRef matching = IOServiceNameMatching("AGXAcceleratorG13G_B0");
 
 	io_service_t service =
-		IOServiceGetMatchingService(kIOMasterPortDefault, matching);
+		IOServiceGetMatchingService(kIOMainPortDefault, matching);
 
 	if (!service) {
 		fprintf(stderr, "G13 (B0) accelerator not found\n");


### PR DESCRIPTION
Signed-off-by: Adeeb Abbas <adeeb.abbas@drexel.edu>

The current master yields the following error. Using deprecated naming, this PR aims to fix it - 

```demo/iokit.c:46:31: error: 'kIOMasterPortDefault' is deprecated: first deprecated in macOS 12.0 [-Werror,-Wdeprecated-declarations]```